### PR TITLE
Remove ref form uploaders on destroy

### DIFF
--- a/es6/constants.js
+++ b/es6/constants.js
@@ -1,7 +1,7 @@
-import keymirror from 'keymirror';
+const keymirror = require('keymirror');
 
 // Copied from plupload
-export const FileStatus = {
+const FileStatus = {
   QUEUED: 1,
   UPLOADING: 2,
   FAILED: 4,
@@ -10,13 +10,13 @@ export const FileStatus = {
 };
 
 // Copied from plupload
-export const States = {
+const States = {
   STOPPED: 1,
   STARTED: 2,
 };
 
 // Copied from plupload
-export const Errors = {
+const Errors = {
   GENERIC_ERROR: -100,
   HTTP_ERROR: -200,
   IO_ERROR: -300,
@@ -31,7 +31,7 @@ export const Errors = {
   OPTION_ERROR: -800,
 };
 
-export const ActionTypes = keymirror({
+const ActionTypes = keymirror({
   INIT: null,
   SET_OPTION: null,
   REFRESH: null,
@@ -64,4 +64,12 @@ export const ActionTypes = keymirror({
 
 Object.keys(ActionTypes).forEach(key => { ActionTypes[key] = `redux-plupload/${key}`; });
 
-export const DEFAULT_UPLOADER_HANDLE = 'default';
+const DEFAULT_UPLOADER_HANDLE = 'default';
+
+module.exports = {
+  FileStatus,
+  States,
+  Errors,
+  ActionTypes,
+  DEFAULT_UPLOADER_HANDLE,
+};

--- a/es6/index.js
+++ b/es6/index.js
@@ -1,3 +1,7 @@
-export { FileStatus, States, Errors, ActionTypes } from './constants';
-export { default as createMiddleware } from './middleware';
-export { default as reducer, createReducer } from './reducer';
+const { FileStatus, States, Errors, ActionTypes } = require('./constants');
+const { createMiddleware } = require('./middleware');
+const { reducer, createReducer } = require('./reducer');
+
+module.exports = {
+  FileStatus, States, Errors, ActionTypes, createMiddleware, reducer, createReducer,
+};

--- a/es6/middleware.js
+++ b/es6/middleware.js
@@ -1,7 +1,7 @@
-import contentDisposition from 'content-disposition';
+const contentDisposition = require('content-disposition');
 
-import { ActionTypes, DEFAULT_UPLOADER_HANDLE } from './constants';
-import { makeSnapshotFunction } from './snapshot';
+const { ActionTypes, DEFAULT_UPLOADER_HANDLE } = require('./constants');
+const { makeSnapshotFunction } = require('./snapshot');
 
 const actionToMethod = {
   [ActionTypes.SET_OPTION]: ['setOption', ({ option, value }) => [option, value]],
@@ -99,7 +99,7 @@ function init(store, plupload, options) {
   return uploader;
 }
 
-export default function createMiddleware(plupload, origOptions = {}) {
+const createMiddleware = function createMiddleware(plupload, origOptions = {}) {
   let uploaders;
   return store => next => action => {
     const { type, payload = {}, meta = {} } = action;
@@ -137,4 +137,6 @@ export default function createMiddleware(plupload, origOptions = {}) {
 
     return next(action);
   };
-}
+};
+
+module.exports = { createMiddleware };

--- a/es6/middleware.js
+++ b/es6/middleware.js
@@ -113,24 +113,32 @@ const createMiddleware = function createMiddleware(plupload, origOptions = {}) {
     }
     if (!uploader) return next(action);
 
-    let method = undefined;
-    let payloadTransform = undefined;
+    const callUploadMethod = (actionType) => {
+      const [method] = actionToMethod[actionType];
+      uploader[method].apply(uploader);
+    };
+
     switch (type) {
       case ActionTypes.REFRESH:
       case ActionTypes.START:
       case ActionTypes.STOP:
-      case ActionTypes.CLEAR:
-      case ActionTypes.DESTROY:
-        [method] = actionToMethod[type];
-        uploader[method].apply(uploader);
+      case ActionTypes.CLEAR: {
+        callUploadMethod(type);
         break;
+      }
+      case ActionTypes.DESTROY: {
+        callUploadMethod(type);
+        delete uploaders[handle];
+        break;
+      }
       case ActionTypes.SET_OPTION:
       case ActionTypes.DISABLE_BROWSE:
       case ActionTypes.ADD_FILE:
-      case ActionTypes.REMOVE_FILE:
-        [method, payloadTransform] = actionToMethod[type] || [];
+      case ActionTypes.REMOVE_FILE: {
+        const [method, payloadTransform] = actionToMethod[type] || [];
         uploader[method].apply(uploader, (payloadTransform(payload) || []));
         break;
+      }
       default:
         break;
     }

--- a/es6/reducer.js
+++ b/es6/reducer.js
@@ -1,6 +1,6 @@
-import { ActionTypes, DEFAULT_UPLOADER_HANDLE } from './constants';
+const { ActionTypes, DEFAULT_UPLOADER_HANDLE } = require('./constants');
 
-export function createReducer(handle = DEFAULT_UPLOADER_HANDLE) {
+const createReducer = function createReducer(handle = DEFAULT_UPLOADER_HANDLE) {
   return function reducer(state = { handle }, { type, meta: { uploader } = {} }) {
     switch (type) {
       case ActionTypes.INITING:
@@ -25,6 +25,6 @@ export function createReducer(handle = DEFAULT_UPLOADER_HANDLE) {
         return state;
     }
   };
-}
+};
 
-export default createReducer();
+module.exports = createReducer;

--- a/es6/snapshot.js
+++ b/es6/snapshot.js
@@ -80,12 +80,17 @@ function mapSnapshotHelper(obj, origRef, context) {
   return snap;
 }
 
-export default function snapshot(obj, ref) {
+const snapshot = function snapshot(obj, ref) {
   return stackSnapshotHelper(obj, ref, { stack: [], snapshotHelper: stackSnapshotHelper });
-}
+};
 
-export function makeSnapshotFunction() {
+const makeSnapshotFunction = function makeSnapshotFunction() {
   const map = new WeakMap();
   return (obj, ref) =>
     mapSnapshotHelper(obj, ref, { map, stack: [], snapshotHelper: mapSnapshotHelper });
-}
+};
+
+module.exports = {
+  snapshot,
+  makeSnapshotFunction,
+};

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "description": "Redux integration for Plupload",
   "license": "MIT",
-  "main": "lib/index.js",
-  "es6:main": "es6/index.js",
+  "main": "es6/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/tes/redux-plupload.git"


### PR DESCRIPTION
@geophree can you have a look.
In our app we have to create/destroy and recreate the uploader and without this fix, it will try to re-init already inited uploader even after destroying it
https://github.com/tes/redux-plupload/blob/master/es6/middleware.js#L110