### PR TITLE
Errors on accessing properties

### DIFF
--- a/es6/snapshot.js
+++ b/es6/snapshot.js
@@ -16,13 +16,13 @@ function snapshotObject(obj, origRef, context) {
     if (ref.hasOwnProperty(key)) foundRefKeys++;
 
     const referenceStateForKey = ref[key];
-    let clonedStateForKey;
-    // In some cases,
-    // properties listed in `Object.keys` may actually throw Errors on read
+    let value;
     try {
-      clonedStateForKey = snapshotHelper(obj[key], referenceStateForKey, context);
-    // eslint-disable-next-line no-empty
-    } catch (e) { }
+      value = obj[key];
+    } catch (e) {
+      // Ignore errors generated accessing properties returned by `Object.keys()`.
+    }
+    const clonedStateForKey = snapshotHelper(value, referenceStateForKey, context);
     clone[key] = clonedStateForKey;
     changed = changed || clonedStateForKey !== referenceStateForKey;
   }

--- a/es6/snapshot.js
+++ b/es6/snapshot.js
@@ -16,7 +16,13 @@ function snapshotObject(obj, origRef, context) {
     if (ref.hasOwnProperty(key)) foundRefKeys++;
 
     const referenceStateForKey = ref[key];
-    const clonedStateForKey = snapshotHelper(obj[key], referenceStateForKey, context);
+    let clonedStateForKey;
+    // In some cases,
+    // properties listed in `Object.keys` may actually throw Errors on read
+    try {
+      clonedStateForKey = snapshotHelper(obj[key], referenceStateForKey, context);
+    // eslint-disable-next-line no-empty
+    } catch (e) { }
     clone[key] = clonedStateForKey;
     changed = changed || clonedStateForKey !== referenceStateForKey;
   }

--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -141,6 +141,15 @@ function defineSnapshotTests(c) {
     obj2.b[0].parent = obj2;
     expect(c.snap(obj2)).to.eql({ b: [{ parent: undefined }] });
   });
+
+  it('handles properties throwing Errors on read', () => {
+    const obj = {
+      get a() {
+        throw Error();
+      },
+    };
+    expect(c.snap(obj)).to.eql({ a: undefined });
+  });
 }
 
 describe('snapshot', () => {


### PR DESCRIPTION
Safari 9.1.2 lists `selectionStart` as `key` of `input[type=file]`, but throws `Error` on reading the value. 

That has broken `snapshot.js`, which in turn just ruined the whole uploading process in Safari.